### PR TITLE
Added native app voice trigger intent so you can say "OK, Glass, start launchy"

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -24,6 +24,11 @@
                 <action android:name="com.google.glass.action.ACTION_GO_TO_SETTINGS" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="com.google.android.glass.action.VOICE_TRIGGER" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <meta-data android:name="com.google.android.glass.voice_trigger" android:resource="@string/voice_menu_trigger" />
         </activity>
     </application>
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -3,5 +3,6 @@
 
     <string name="app_name">Launchy</string>
     <string name="launch">Launch... </string>
+    <string name="voice_menu_trigger">start launchy</string>
 
 </resources>


### PR DESCRIPTION
![device-2013-06-01-113924](https://f.cloud.github.com/assets/704768/595219/1766a4a2-caeb-11e2-920a-15bdf8d372b7.png)
This only works with devices that has the lab NATIVE_APP_VOICE enabled, see https://gist.github.com/zhuowei/5624527 I tested it with a Nexus 7 running the Xenologer APKs.

see #5 for previous discussion.
