### PR TITLE
Update the application list when some apps are installed or uninstalled

### DIFF
--- a/src/com/mikedg/android/glass/launchy/MainActivity.java
+++ b/src/com/mikedg/android/glass/launchy/MainActivity.java
@@ -36,12 +36,6 @@ public class MainActivity extends Activity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        mAppHelper = new AppHelper(this);
-        mAppHelper.loadApplications(true);
-
-        mAppHelper.bindApplications();
-        mAppHelper.registerIntentReceivers();
-
         // setupTestReceiver();
 
         final ListView list = (ListView) findViewById(android.R.id.list);
@@ -57,6 +51,17 @@ public class MainActivity extends Activity {
 
             }
         });
+    }
+
+    @Override
+    protected void onResume(){
+        super.onResume();
+
+        mAppHelper = new AppHelper(this);
+        mAppHelper.loadApplications(true);
+
+        mAppHelper.bindApplications();
+        mAppHelper.registerIntentReceivers();
 
         IntentFilter intentFilter = new IntentFilter();
         intentFilter.addAction(Intent.ACTION_PACKAGE_ADDED);


### PR DESCRIPTION
The current version sometimes misses the installation of new app.
Launcher app should check the application list whenever its process returns to foreground.
